### PR TITLE
fix: 附录图表编号显示不正确、公式编号不正确、目录双标题

### DIFF
--- a/template.typ
+++ b/template.typ
@@ -1,5 +1,5 @@
 #import "constants.typ":字体,字号,行距
-#import "utils.typ":set_doc,set_doc_footnote
+#import "utils.typ":set_doc,set_doc_footnote,part_state
 
 //论文翻译封面
 #let translation_cover(
@@ -194,15 +194,15 @@
       #it.page.at("child")
     ]
   }
+  heading(level: 1, bookmarked: true, outlined: true)[目#h(2em)录]
+  v(0.6em)
   outline(
-    title:[
-      = 目#h(2em)录#v(0.6em)
-    ],
-    indent:2em
+    title: none,
+    indent: 2em,
+    depth: 3,
   )
   set par(first-line-indent: 2em)
-  place(top,hide([= 目#h(2em)录])) // hack outline cannot outline itself
-  
+
 }
 
 //参考文献页
@@ -215,6 +215,7 @@
 
 #let appendix(doc) = {
   counter(heading).update(0)
+  part_state.update("appendix")
   set heading(numbering: (..nums)=>{
     let nums_array = nums.pos()
     if nums_array.len()==1{

--- a/utils.typ
+++ b/utils.typ
@@ -228,7 +228,17 @@
           }
         }))
       }
-      else{
+      else if el!=none and el.func() == math.equation {
+        if continuous_index {
+          return it
+        } else {
+          "公式 ("
+          get_chapter_idx_display(loc: el.location())
+          "."
+          str(counter(math.equation).at(el.location()).first())
+          ")"
+        }
+      } else {
         return it
       }
     }

--- a/utils.typ
+++ b/utils.typ
@@ -149,12 +149,12 @@
 #let set_doc_figure(doc,continuous_index:false) = {
 
   //子图使用(a)编号，图编号样式:2-1，表样式:2.1。可选择全文连续编号
-  let figure_numbering(idx,kind:none) = {
+  let figure_numbering(idx,kind:none,loc:none) = {
     if kind=="subfigure"{
       return numbering("(a)",idx)
     }
     let separator = if kind==image{"-"} else{"."}
-    let chapter_idx = get_chapter_idx_display()
+    let chapter_idx = get_chapter_idx_display(loc: loc)
     if not continuous_index{
       return [#{chapter_idx}#separator#idx]
     }
@@ -214,7 +214,7 @@
         let supplement = if el.kind==image{"图"} else{"表"}
         return link(el.location(),locate(loc=>{
           supplement
-          figure_numbering(..el.counter.at(el.location()),kind:el.kind) //图表引用格式同caption格式
+          figure_numbering(..el.counter.at(el.location()),kind:el.kind,loc:el.location()) //图表引用格式同caption格式
         }))
       }
       else{

--- a/utils.typ
+++ b/utils.typ
@@ -85,7 +85,7 @@
 }
 
 //设置各级标题格式
-#let set_doc_heading(doc) = {
+#let set_doc_heading(doc, continuous_index: false) = {
   //章标题
   show heading.where(level:1):it=>{
     pagebreak()
@@ -96,6 +96,11 @@
     text()[#v(0em, weak: true)]
     text()[#h(0em)]
     v(0.2em)
+
+    if not continuous_index {
+      counter(math.equation).update(0)
+      // 用于解决公式跨章节连续编号的问题
+    }
   }
   //节标题
   show heading.where(level:2):it=>{
@@ -214,7 +219,13 @@
         let supplement = if el.kind==image{"图"} else{"表"}
         return link(el.location(),locate(loc=>{
           supplement
-          figure_numbering(..el.counter.at(el.location()),kind:el.kind,loc:el.location()) //图表引用格式同caption格式
+          if continuous_index {
+            str(
+              figure_numbering(..el.counter.at(el.location()),kind:el.kind,loc:el.location()) //图表引用格式同caption格式
+            )
+          } else {
+            figure_numbering(..el.counter.at(el.location()),kind:el.kind,loc:el.location())
+          }
         }))
       }
       else{
@@ -235,7 +246,7 @@
       return [(#{chapter_idx}.#idx)] //按章节编号
     }
     else{
-      return idx
+      return [(#idx)]
     }
   })
   doc
@@ -244,7 +255,7 @@
 //统一设置正文格式
 #let set_doc(doc,continuous_index:false) = {
   let doc = set_doc_basic(doc)
-  let doc = set_doc_heading(doc)
+  let doc = set_doc_heading(doc, continuous_index:continuous_index)
   
   let doc = set_doc_figure(doc,continuous_index:continuous_index)
   let doc = set_doc_math(doc,continuous_index:continuous_index)

--- a/utils.typ
+++ b/utils.typ
@@ -4,6 +4,8 @@
 #let midhline = hlinex(stroke:0.7pt)
 #let midvline = vlinex(stroke:0.5pt)
 
+#let part_state = state("part")
+
 //使用terms模拟latex的paragraph
 #let paragraph(content) = {
   set terms(hanging-indent: 0pt,indent:0pt)
@@ -20,6 +22,15 @@
   else{
     return counter(heading).at(loc).first()
   }
+})
+
+//获取用于显示的章节序号 
+#let get_chapter_idx_display(loc: none) = locate(cur_loc => {
+  let loc = if loc != none {loc} else {cur_loc}
+  let chapter_idx = counter(heading).at(loc).first()
+  let is_appendix = if part_state.at(loc) == "appendix" {true} else {false}
+
+  return numbering(if is_appendix {"A"} else {"1"}, chapter_idx)
 })
 
 //使用typst的画圈功能实现带圈数字
@@ -143,7 +154,7 @@
       return numbering("(a)",idx)
     }
     let separator = if kind==image{"-"} else{"."}
-    let chapter_idx = get_chapter_idx()
+    let chapter_idx = get_chapter_idx_display()
     if not continuous_index{
       return [#{chapter_idx}#separator#idx]
     }
@@ -194,7 +205,7 @@
       locate(loc=>{
         let parent_fig = query(figure.where(kind:image).before(subfig_loc),loc).last() //获得所在大图
         let parent_fig_idx = parent_fig.counter.at(subfig_loc).first() //获得大图序号
-        let chapter_idx = get_chapter_idx(loc:subfig_loc) //获得章节序号
+        let chapter_idx = get_chapter_idx_display(loc:subfig_loc) //获得章节序号
         return link(subfig_loc)[图#{chapter_idx}-#{parent_fig_idx}~(#it)] //子图引用格式:图2-1(a)
       })
     }
@@ -219,7 +230,7 @@
 #let set_doc_math(doc,continuous_index:false) = {
 
   set math.equation(numbering: idx=>{
-    let chapter_idx = get_chapter_idx()
+    let chapter_idx = get_chapter_idx_display()
     if not continuous_index{
       return [(#{chapter_idx}.#idx)] //按章节编号
     }


### PR DESCRIPTION
## 目录部分

目录部分的标题改为一个 `level:1` 的 `heading`，避免显隐双标题。

## 附录编号部分

> **Bug**
> 
> 原本在附录部分使用图表或公式，会依旧使用正文的 `"1-1"` `"1.1"` 格式。

此 PR 增加了一个维护状态的 `part_state` 用于标示目前所在的章节环境，并在不同的环境中使用不同的编号。

请注意：在 `#appendix` 内及 **`#appendix` 后**的所有内容， `part_state` 均为 `"appendix"`。

## 公式编号部分

> **Bug**
> 
> 原本即使 `continuous_index: false`，公式总是跨页连续编号。

此 PR 在 `heading` 中增加了一个使 `counter(math.equation)` 归零的判断，并将 `continuous_index: true` 时的公式 ref 格式由 `公式1` 修改为 `公式(1)` 以符合教务处模板。