### PR TITLE
fix: 修复参考文献条目不渲染最后的 `. `

### DIFF
--- a/gb-t-7714-2015-numeric-seu-bachelor.csl
+++ b/gb-t-7714-2015-numeric-seu-bachelor.csl
@@ -22,7 +22,7 @@
     <category citation-format="numeric"/>
     <category field="generic-base"/>
     <summary>1. 适用于 Typst 0.11.0 ，与 bilingual-bibliography 配合使用可按照语言显示“等”或“et al.”；2. 仅纯电子资源显示引用日期和 URL；3. 无 DOI。</summary>
-    <updated>2024-05-02T19:21:32+08:00</updated>
+    <updated>2024-05-22T21:40:32+08:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="zh">
@@ -396,7 +396,7 @@
   </macro>
   <!-- 参考文献表格式 -->
   <macro name="entry-layout">
-    <group delimiter=". ">
+    <group delimiter=". " suffix=".">
       <text macro="author"/>
       <choose>
         <if type="periodical">


### PR DESCRIPTION
更新 CSL 文件，修复不显示条目最后的 `. ` 的问题。

![image](https://github.com/TideDra/seu-thesis-typst/assets/117500413/2a3f32a6-0d16-4dcf-80b1-c845061a6873)

（标黄色的点）
